### PR TITLE
Handling Redis instances behind Sentinels

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -29,15 +29,57 @@ $ mvn clean package
 
 == Installing
 
-Unzip the gravitee-repository-redis-1.20.0-SNAPSHOT.zip in the gravitee home directory.
+Unzip the gravitee-repository-redis-3.1.0-SNAPSHOT.zip in the gravitee home directory.
 
 == Configuration
 
-  repository.redis options :
+  repository.redis options (standalone) :
 
   | Parameter                                        |   default  |
   | ------------------------------------------------ | ---------: |
-  | host                                             |  localhost |
+  | host                                             | localhost  |
   | port                                             |      6379  |
   | password                                         |            |
-  | timeout                                          |        -1  |
+  | timeout                                          |   1000 ms  |
+
+  repository.redis options (using sentinel) :
+
+  | Parameter                                        |   default  |
+  | ------------------------------------------------ | ---------: |
+  | sentinel.nodes                                   |            |
+  | sentinel.password                                |            |
+  | sentinel.master (mandatory when using Sentinel)  |            |
+  | password                                         |            |
+  | timeout                                          |   1000 ms  |
+
+Examples :
+
+_Standalone redis_ :
+
+[source,yaml]
+----
+redis:
+  host: 'redis.mycompany'
+  port: 6379
+  password: 'mysecretpassword'
+  timeout: 2000
+----
+
+_Redis replicaset behind Sentinels_ :
+
+[source,yaml]
+----
+redis:
+  sentinel:
+    master: 'mymaster'
+    nodes:
+      - host: 'sentinel-1.mycompany'
+        port: 26379
+      - host: 'sentinel-2.mycompany'
+        port: 26379
+      - host: 'sentinel-3.mycompany'
+        port: 26379
+    password: 'sentinel-password'
+  password: 'redis-password'
+  timeout: 2000
+----

--- a/pom.xml
+++ b/pom.xml
@@ -23,20 +23,21 @@
 	<parent>
 		<groupId>io.gravitee</groupId>
 		<artifactId>gravitee-parent</artifactId>
-		<version>17.1</version>
+		<version>19</version>
 	</parent>
 
 	<groupId>io.gravitee.repository</groupId>
 	<artifactId>gravitee-repository-redis</artifactId>
-	<version>3.0.3</version>
+	<version>3.1.0-SNAPSHOT</version>
 	<name>Gravitee.io APIM - Repository - Redis</name>
 
 	<properties>
-		<gravitee-repository.version>3.0.4</gravitee-repository.version>
-		<jedis.version>2.9.3</jedis.version>
-		<spring-data-redis.version>1.8.23.RELEASE</spring-data-redis.version>
+		<gravitee-repository.version>3.2.0</gravitee-repository.version>
+		<lettuce.version>5.3.4.RELEASE</lettuce.version>
+		<spring-data-redis.version>2.3.4.RELEASE</spring-data-redis.version>
 		<maven-dependency-plugin.version>2.10</maven-dependency-plugin.version>
-		<embedded-redis.version>0.6</embedded-redis.version>
+		<commons-lang3.version>3.9</commons-lang3.version>
+		<commons-pool2.version>2.9.0</commons-pool2.version>
 	</properties>
 
 	<dependencies>
@@ -55,11 +56,11 @@
 			<scope>provided</scope>
 		</dependency>
 
-		<!-- Jedis -->
+		<!-- Lettuce -->
 		<dependency>
-			<groupId>redis.clients</groupId>
-			<artifactId>jedis</artifactId>
-			<version>${jedis.version}</version>
+			<groupId>io.lettuce</groupId>
+			<artifactId>lettuce-core</artifactId>
+			<version>${lettuce.version}</version>
 		</dependency>
 
 		<!-- Spring dependencies -->
@@ -89,6 +90,17 @@
 			<scope>provided</scope>
 		</dependency>
 
+		<!-- Apache commons -->
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>${commons-lang3.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-pool2</artifactId>
+			<version>${commons-pool2.version}</version>
+		</dependency>
 		<!--  Logging -->
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
@@ -108,12 +120,6 @@
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-test</artifactId>
 			<version>${spring.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.github.kstyrc</groupId>
-			<artifactId>embedded-redis</artifactId>
-			<version>${embedded-redis.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/src/main/java/io/gravitee/repository/redis/RedisRepository.java
+++ b/src/main/java/io/gravitee/repository/redis/RedisRepository.java
@@ -15,11 +15,11 @@
  */
 package io.gravitee.repository.redis;
 
-import org.springframework.data.redis.connection.jedis.JedisConnection;
 
 import io.gravitee.repository.Repository;
 import io.gravitee.repository.Scope;
 import io.gravitee.repository.redis.ratelimit.RateLimitRepositoryConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnection;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -32,7 +32,7 @@ public class RedisRepository implements Repository {
         try {
             Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
             try {
-                Class.forName(JedisConnection.class.getName(), true, getClass().getClassLoader());
+                Class.forName(LettuceConnection.class.getName(), true, getClass().getClassLoader());
             } catch (ClassNotFoundException e) {
             }
         } finally {


### PR DESCRIPTION
- Choosing the right Redis client configuration based on the repository's parameters : standalone redis instance or sentinels - redis master / replicates
- Upgrading spring-data-redis to 2.3.4.RELEASE
- Switching to lettuce client (instead of Jedis) to support sentinel authentication. If we want to keep Jedis, we will have to wait for the release of Spring Data Redis 2.4 (RC 2 at the moment)

This closes gravitee-io/issues#79